### PR TITLE
GP-8132 Fix creation of unrelated custom activity entities

### DIFF
--- a/api/v3/Contract/ProcessScheduledModifications.php
+++ b/api/v3/Contract/ProcessScheduledModifications.php
@@ -72,6 +72,7 @@ function civicrm_api3_Contract_process_scheduled_modifications($params) {
   $counter = 0;
   $scheduled_activities = civicrm_api3('Activity', 'get', $activityParams);
   foreach ($scheduled_activities['values'] as $scheduled_activity) {
+    CRM_Contract_Utils::stripNonContractActivityCustomFields($scheduled_activity);
     $counter++;
     if ($counter > $params['limit']) {
       break;

--- a/tests/phpunit/CRM/Contract/UtilsTest.php
+++ b/tests/phpunit/CRM/Contract/UtilsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use CRM_Contract_ExtensionUtil as E;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Test utility functions
+ *
+ * @group headless
+ */
+class CRM_Contract_UtilsTest extends CRM_Contract_ContractTestBase {
+
+  public function testStripNonContractActivityCustomFields() {
+    $fields = CRM_Contract_CustomData::getCustomFieldsForGroups(['contract_cancellation','contract_updates']);
+    $activityData = [
+      'id'                         => 1,
+      'activity_date_time'         => '20200101000000',
+      'custom_' . $fields[0]['id'] => 'foo',
+      'custom_9997'                => 'bar',
+      'custom_9998_1'              => 'baz',
+    ];
+    CRM_Contract_Utils::stripNonContractActivityCustomFields($activityData);
+    $this->assertArraysEqual([
+        'id'                         => 1,
+        'activity_date_time'         => '20200101000000',
+        'custom_' . $fields[0]['id'] => 'foo',
+      ],
+      $activityData
+    );
+  }
+
+}


### PR DESCRIPTION
In APIv3, when `Activity.get` receives a request for a custom field via the return parameter, it returns other, unrelated custom fields if they have a default value set. This is true even if the custom field should not be available for the relevant activity type.

In `Contract.process_scheduled_modifications`, this code is triggered and the result of such a call is then passed to CE. The called code then calls `Activity.create` with these unrelated custom fields set, leading to the actual creation of these rows.

This adds a workaround that strips these custom fields before passing the API results to the engine. A better long-term fix would be to move the relevant code to APIv4.