### PR TITLE
GP-9616 Fix issues with reused recurring contributions

### DIFF
--- a/CRM/Contract/Change.php
+++ b/CRM/Contract/Change.php
@@ -126,15 +126,25 @@ abstract class CRM_Contract_Change implements  CRM_Contract_Change_SubjectRender
   /**
    * Make sure that the data for this change is valid
    *
+   * This performs checks that apply to all contract changes. Further checks
+   * may be performed in child classes.
+   *
    * @throws Exception if the data is not valid
    */
   public function verifyData() {
-    // simply check if all required fields are there
-    // ...anything else needs to be checked in the specific class...
+    // check if all required fields are there
     $required_fields = $this->getRequiredFields();
     foreach ($required_fields as $required_field) {
       if (!isset($this->data[$required_field])) {
         throw new Exception("Parameter '{$required_field}' missing.");
+      }
+    }
+    // if a recurring contribution is associated with this change, check that it
+    // is not yet in use by another contract
+    if (!empty($this->data['contract_updates.ch_recurring_contribution'])) {
+      $rcur = new CRM_Contract_RecurringContribution();
+      if (!$rcur->isAssignableToContract($this->data['contract_updates.ch_recurring_contribution'], $this->getContractID())) {
+        throw new Exception('Recurring contribution already in use for different contract');
       }
     }
   }

--- a/CRM/Contract/Form/Create.php
+++ b/CRM/Contract/Form/Create.php
@@ -27,7 +27,7 @@ class CRM_Contract_Form_Create extends CRM_Core_Form {
     $this->assign('contact', $this->contact);
 
     $formUtils = new CRM_Contract_FormUtils($this, 'Membership');
-    $formUtils->addPaymentContractSelect2('recurring_contribution', $this->get('cid'), false, null);
+    $formUtils->addPaymentContractSelect2('recurring_contribution', $this->get('cid'), FALSE);
     CRM_Core_Resources::singleton()->addVars('de.systopia.contract', array(
       'cid'                     => $this->get('cid'),
       'debitor_name'            => $this->contact['display_name'],

--- a/CRM/Contract/Form/Modify.php
+++ b/CRM/Contract/Form/Modify.php
@@ -142,7 +142,7 @@ class CRM_Contract_Form_Modify extends CRM_Core_Form{
       // 'graceful_collections'    => CRM_Contract_SepaLogic::getNextCollections(),
       'action'                  => $this->modify_action,
       'current_contract'        => CRM_Contract_RecurringContribution::getCurrentContract($this->membership['contact_id'], $this->membership[CRM_Contract_Utils::getCustomFieldId('membership_payment.membership_recurring_contribution')]),
-      'recurring_contributions' => CRM_Contract_RecurringContribution::getAllForContact($this->membership['contact_id'], TRUE, $this->get('id'))));
+      'recurring_contributions' => CRM_Contract_RecurringContribution::getAllForContact($this->membership['contact_id'], TRUE)));
     CRM_Contract_SepaLogic::addJsSepaTools();
 
     // add a generic switch to clean up form
@@ -158,7 +158,7 @@ class CRM_Contract_Form_Modify extends CRM_Core_Form{
 
 
     $formUtils = new CRM_Contract_FormUtils($this, 'Membership');
-    $formUtils->addPaymentContractSelect2('recurring_contribution', $this->membership['contact_id'], false, $this->get('id'));
+    $formUtils->addPaymentContractSelect2('recurring_contribution', $this->membership['contact_id'], FALSE);
 
     // Membership type (membership)
     foreach(civicrm_api3('MembershipType', 'get', ['options' => ['limit' => 0, 'sort' => 'weight']])['values'] as $MembershipType){

--- a/CRM/Contract/FormUtils.php
+++ b/CRM/Contract/FormUtils.php
@@ -8,174 +8,192 @@
 | http://www.systopia.de/                                      |
 +--------------------------------------------------------------*/
 
-class CRM_Contract_FormUtils
-{
-    public function __construct($form, $entity)
-    {
-        // The form object and type of entity that we are updating with the form
-        // is passed via the constructor
-        $this->entity = $entity;
-        $this->form = $form;
-        $this->recurringContribution = new CRM_Contract_RecurringContribution;
+class CRM_Contract_FormUtils {
 
+  public function __construct($form, $entity) {
+    // The form object and type of entity that we are updating with the form
+    // is passed via the constructor
+    $this->entity = $entity;
+    $this->form = $form;
+    $this->recurringContribution = new CRM_Contract_RecurringContribution();
+
+  }
+
+  public function addPaymentContractSelect2($elementName, $contactId, $required = TRUE, $contractId) {
+    $recurringContributionOptions[''] = '- none -';
+    foreach ($this->recurringContribution->getAll($contactId, TRUE, $contractId) as $key => $rc) {
+      $recurringContributionOptions[$key] = $rc['label'];
     }
+    $this->form->add('select', $elementName, ts('Mandate / Recurring Contribution'), $recurringContributionOptions, $required, ['class' => 'crm-select2 huge']);
+  }
 
-    public function addPaymentContractSelect2($elementName, $contactId, $required = true, $contractId)
-    {
-        $recurringContributionOptions[''] = '- none -';
-        foreach($this->recurringContribution->getAll($contactId, true, $contractId) as $key => $rc){
-          $recurringContributionOptions[$key] = $rc['label'];
-        }
-        $this->form->add('select', $elementName, ts('Mandate / Recurring Contribution'), $recurringContributionOptions, $required, array('class' => 'crm-select2 huge'));
-    }
+  public function replaceIdWithLabel($name, $entity) {
+    [$groupName, $fieldName] = explode('.', $name);
+    $result = civicrm_api3('CustomField', 'getsingle', [
+      'custom_group_id' => $groupName,
+      'name' => $fieldName,
+    ]);
 
-    public function replaceIdWithLabel($name, $entity)
-    {
-        list($groupName, $fieldName) = explode('.', $name);
-        $result = civicrm_api3('CustomField', 'getsingle', array('custom_group_id' => $groupName, 'name' => $fieldName));
+    $id = CRM_Contract_Utils::getCustomFieldId($name);
 
-        $id = CRM_Contract_Utils::getCustomFieldId($name);
+    // Get the custom data that was sent to the template
+    $details = $this->form->get_template_vars('viewCustomData');
 
-        // Get the custom data that was sent to the template
-        $details = $this->form->get_template_vars('viewCustomData');
-
-        // We need to know the id for the row of the custom group table that
-        // this custom data is stored in
-        if (isset($details[$result['custom_group_id']])) {
-          $customGroupTableId = key($details[$result['custom_group_id']]);
-          if (!empty($details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'])) {
-            $entityId = $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'];
-            if($entity == 'ContributionRecur'){
-              try {
-                $entityResult = civicrm_api3($entity, 'getsingle', array('id' => $entityId));
-                $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = $this->recurringContribution->writePaymentContractLabel($entityResult);
-              } catch (Exception $e) {
-                $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = ts("NOT FOUND!");
-              }
-            }elseif($entity == 'BankAccountReference'){
-              $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = CRM_Contract_BankingLogic::getIBANforBankAccount($entityId);
-            }elseif($entity == 'PaymentInstrument'){
-              $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = civicrm_api3('OptionValue', 'getvalue', ['return' => "label", 'value' => $entityId, 'option_group_id' => "payment_instrument" ]);
-            }
-            // Write nice text and return this to the template
-            $this->form->assign('viewCustomData', $details);
+    // We need to know the id for the row of the custom group table that
+    // this custom data is stored in
+    if (isset($details[$result['custom_group_id']])) {
+      $customGroupTableId = key($details[$result['custom_group_id']]);
+      if (!empty($details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'])) {
+        $entityId = $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'];
+        if ($entity == 'ContributionRecur') {
+          try {
+            $entityResult = civicrm_api3($entity, 'getsingle', ['id' => $entityId]);
+            $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = $this->recurringContribution->writePaymentContractLabel($entityResult);
+          } catch (Exception $e) {
+            $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = ts("NOT FOUND!");
           }
         }
+        elseif ($entity == 'BankAccountReference') {
+          $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = CRM_Contract_BankingLogic::getIBANforBankAccount($entityId);
+        }
+        elseif ($entity == 'PaymentInstrument') {
+          $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = civicrm_api3('OptionValue', 'getvalue', [
+            'return' => "label",
+            'value' => $entityId,
+            'option_group_id' => "payment_instrument",
+          ]);
+        }
+        // Write nice text and return this to the template
+        $this->form->assign('viewCustomData', $details);
+      }
     }
+  }
 
-    /**
-     * The currency for custom fields always defaults to the default currency.
-     * This converts the membership_payment.membership_annual field to string
-     * and manually formats it with the currency obtained from the recurring
-     * contribution.
-     *
-     * @throws \CiviCRM_API3_Exception
-     */
-    public function setPaymentAmountCurrency() {
-      $result = civicrm_api3('CustomField', 'getsingle', array('custom_group_id' => 'membership_payment', 'name' => 'membership_recurring_contribution'));
-      $details = $this->form->get_template_vars('viewCustomData');
+  /**
+   * The currency for custom fields always defaults to the default currency.
+   * This converts the membership_payment.membership_annual field to string
+   * and manually formats it with the currency obtained from the recurring
+   * contribution.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function setPaymentAmountCurrency() {
+    $result = civicrm_api3('CustomField', 'getsingle', [
+      'custom_group_id' => 'membership_payment',
+      'name' => 'membership_recurring_contribution',
+    ]);
+    $details = $this->form->get_template_vars('viewCustomData');
+    $customGroupTableId = key($details[$result['custom_group_id']]);
+    $recContributionId = $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'];
+    $recContribution = civicrm_api3('ContributionRecur', 'getsingle', ['id' => $recContributionId]);
+    $customGroupTableId = key($details[$result['custom_group_id']]);
+    $result = civicrm_api3('CustomField', 'getsingle', [
+      'custom_group_id' => 'membership_payment',
+      'name' => 'membership_annual',
+    ]);
+    $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = CRM_Utils_Money::format($details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'], $recContribution['currency']);
+    $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_data_type'] = 'String';
+    $this->form->assign('viewCustomData', $details);
+  }
+
+  public function showMembershipTypeLabel() {
+    $result = civicrm_api3('CustomField', 'getsingle', [
+      'custom_group_id' => 'contract_updates',
+      'name' => 'ch_membership_type',
+    ]);
+    // Get the custom data that was sent to the template
+    $details = $this->form->get_template_vars('viewCustomData');
+
+    // We need to know the id for the row of the custom group table that
+    // this custom data is stored in
+    if (!empty($details[$result['custom_group_id']])) {
       $customGroupTableId = key($details[$result['custom_group_id']]);
-      $recContributionId = $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'];
-      $recContribution = civicrm_api3('ContributionRecur', 'getsingle', array('id' => $recContributionId));
-      $customGroupTableId = key($details[$result['custom_group_id']]);
-      $result = civicrm_api3('CustomField', 'getsingle', array('custom_group_id' => 'membership_payment', 'name' => 'membership_annual'));
-      $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = CRM_Utils_Money::format($details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'], $recContribution['currency']);
-      $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_data_type'] = 'String';
-      $this->form->assign('viewCustomData', $details);
+
+      $membershipTypeId = $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'];
+      if ($membershipTypeId) {
+        $membershipType = civicrm_api3('MembershipType', 'getsingle', ['id' => $membershipTypeId]);
+
+        // Write nice text and return this to the template
+        $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = $membershipType['name'];
+        $this->form->assign('viewCustomData', $details);
+      }
     }
+  }
 
-    public function showMembershipTypeLabel()
-    {
-        $result = civicrm_api3('CustomField', 'getsingle', array('custom_group_id' => 'contract_updates', 'name' => 'ch_membership_type'));
-        // Get the custom data that was sent to the template
-        $details = $this->form->get_template_vars('viewCustomData');
+  public function removeMembershipEditDisallowedCoreFields() {
+    foreach ($this->getMembershpEditDisallowedCoreFields() as $element) {
+      if ($this->form->elementExists($element)) {
+        $this->form->removeElement($element);
+      }
+    }
+  }
 
-        // We need to know the id for the row of the custom group table that
-        // this custom data is stored in
-        if (!empty($details[$result['custom_group_id']])) {
-          $customGroupTableId = key($details[$result['custom_group_id']]);
+  public function getMembershpEditDisallowedCoreFields() {
+    return ['status_id', 'is_override'];
+  }
 
-          $membershipTypeId = $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'];
-          if($membershipTypeId){
-              $membershipType = civicrm_api3('MembershipType', 'getsingle', ['id' => $membershipTypeId]);
+  public function removeMembershipEditDisallowedCustomFields() {
+    // $customGroupsToRemove = array('membership_cancellation');
+    $customGroupsToRemove = [];
+    $customFieldsToRemove['membership_payment'] = [];
 
-              // Write nice text and return this to the template
-              $details[$result['custom_group_id']][$customGroupTableId]['fields'][$result['id']]['field_value'] = $membershipType['name'];
-              $this->form->assign('viewCustomData', $details);
+    foreach ($this->form->_groupTree as $groupKey => $group) {
+      if (in_array($group['name'], $customGroupsToRemove)) {
+        unset($this->form->_groupTree[$groupKey]);
+      }
+      else {
+        foreach ($group['fields'] as $fieldKey => $field) {
+          if (isset($customFieldsToRemove[$group['name']]) && in_array($field['column_name'], $customFieldsToRemove[$group['name']])) {
+            unset($this->form->_groupTree[$groupKey]['fields'][$fieldKey]);
           }
-        }
-    }
-
-    public function removeMembershipEditDisallowedCoreFields()
-    {
-        foreach ($this->getMembershpEditDisallowedCoreFields() as $element) {
-            if ($this->form->elementExists($element)) {
-                $this->form->removeElement($element);
-            }
-        }
-    }
-
-    public function getMembershpEditDisallowedCoreFields()
-    {
-        return array('status_id', 'is_override');
-    }
-
-    public function removeMembershipEditDisallowedCustomFields()
-    {
-        // $customGroupsToRemove = array('membership_cancellation');
-        $customGroupsToRemove = array();
-        $customFieldsToRemove['membership_payment'] = array();
-
-        foreach ($this->form->_groupTree as $groupKey => $group) {
-            if (in_array($group['name'], $customGroupsToRemove)) {
-                unset($this->form->_groupTree[$groupKey]);
-            } else {
-                foreach ($group['fields'] as $fieldKey => $field) {
-                    if (isset($customFieldsToRemove[$group['name']]) && in_array($field['column_name'], $customFieldsToRemove[$group['name']])) {
-                        unset($this->form->_groupTree[$groupKey]['fields'][$fieldKey]);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Add a download link to the custom field membership_contract
-     * @param $membershipId
-     */
-    public function addMembershipContractFileDownloadLink($membershipId) {
-      $membershipContractCustomField = civicrm_api3('CustomField', 'getsingle', array('name' => "membership_contract", 'return' => "id"));
-      $membership = civicrm_api3('Membership','getsingle', array('id' => $membershipId));
-      if (!empty($membership['custom_'.$membershipContractCustomField['id']])) {
-        $membershipContract = $membership['custom_'.$membershipContractCustomField['id']];
-        $contractFile = CRM_Contract_Utils::contractFileExists($membershipContract);
-        if ($contractFile) {
-          $script = file_get_contents(CRM_Core_Resources::singleton()->getUrl('de.systopia.contract', 'templates/CRM/Member/Form/MembershipView.js'));
-          $url = CRM_Utils_System::url('civicrm/contract/download', "contract=".urlencode($membershipContract));
-          $script = str_replace('CONTRACT_FILE_DOWNLOAD', $url, $script);
-          CRM_Core_Region::instance('page-footer')->add(array(
-            'script' => $script,
-            'name'   => 'contract-download@de.systopia.contract',
-          ));
         }
       }
     }
+  }
 
-    /**
-     * Called from civicrm/contract/download?contract={contract_id}
-     * This function downloads a contract file via the users web browser
-     */
-    public function downloadMembershipContract() {
-      // If we requested a contract file download
-      $download = CRM_Utils_Request::retrieve('contract', 'String', CRM_Core_DAO::$_nullObject, FALSE, '', 'GET');
-      if (!empty($download)) {
-        // FIXME: Could use CRM_Utils_System::download but it still requires you to do all the work (load file to stream etc) before calling.
-        if (CRM_Contract_Utils::downloadContractFile($download)) {
-          CRM_Utils_System::civiExit();
-        }
-        // If the file didn't exist
-        echo "File does not exist";
+  /**
+   * Add a download link to the custom field membership_contract
+   *
+   * @param $membershipId
+   */
+  public function addMembershipContractFileDownloadLink($membershipId) {
+    $membershipContractCustomField = civicrm_api3('CustomField', 'getsingle', [
+      'name' => "membership_contract",
+      'return' => "id",
+    ]);
+    $membership = civicrm_api3('Membership', 'getsingle', ['id' => $membershipId]);
+    if (!empty($membership['custom_' . $membershipContractCustomField['id']])) {
+      $membershipContract = $membership['custom_' . $membershipContractCustomField['id']];
+      $contractFile = CRM_Contract_Utils::contractFileExists($membershipContract);
+      if ($contractFile) {
+        $script = file_get_contents(CRM_Core_Resources::singleton()
+          ->getUrl('de.systopia.contract', 'templates/CRM/Member/Form/MembershipView.js'));
+        $url = CRM_Utils_System::url('civicrm/contract/download', "contract=" . urlencode($membershipContract));
+        $script = str_replace('CONTRACT_FILE_DOWNLOAD', $url, $script);
+        CRM_Core_Region::instance('page-footer')->add([
+          'script' => $script,
+          'name' => 'contract-download@de.systopia.contract',
+        ]);
+      }
+    }
+  }
+
+  /**
+   * Called from civicrm/contract/download?contract={contract_id}
+   * This function downloads a contract file via the users web browser
+   */
+  public function downloadMembershipContract() {
+    // If we requested a contract file download
+    $download = CRM_Utils_Request::retrieve('contract', 'String', CRM_Core_DAO::$_nullObject, FALSE, '', 'GET');
+    if (!empty($download)) {
+      // FIXME: Could use CRM_Utils_System::download but it still requires you to do all the work (load file to stream etc) before calling.
+      if (CRM_Contract_Utils::downloadContractFile($download)) {
         CRM_Utils_System::civiExit();
       }
+      // If the file didn't exist
+      echo "File does not exist";
+      CRM_Utils_System::civiExit();
     }
+  }
+
 }

--- a/CRM/Contract/FormUtils.php
+++ b/CRM/Contract/FormUtils.php
@@ -19,7 +19,7 @@ class CRM_Contract_FormUtils {
 
   }
 
-  public function addPaymentContractSelect2($elementName, $contactId, $required = TRUE, $contractId) {
+  public function addPaymentContractSelect2($elementName, $contactId, $required = TRUE, $contractId = NULL) {
     $recurringContributionOptions[''] = '- none -';
     foreach ($this->recurringContribution->getAll($contactId, TRUE, $contractId) as $key => $rc) {
       $recurringContributionOptions[$key] = $rc['label'];

--- a/CRM/Contract/RecurringContribution.php
+++ b/CRM/Contract/RecurringContribution.php
@@ -181,6 +181,30 @@ class CRM_Contract_RecurringContribution {
     return $return;
   }
 
+  /**
+   * Check if a recurring contribution can be assigned to a contract
+   *
+   * @param $contribution_recur_id
+   * @param $contract_id
+   *
+   * @return bool
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function isAssignableToContract($contribution_recur_id, $contract_id) {
+    $rcField = CRM_Contract_Utils::getCustomFieldId('membership_payment.membership_recurring_contribution');
+    $contract_using_rc = civicrm_api3('Membership', 'getcount', [
+      $rcField  => $contribution_recur_id,
+      'id'      => ['<>' => $contract_id],
+    ]);
+    $rcUpdateField = CRM_Contract_Utils::getCustomFieldId('contract_updates.ch_recurring_contribution');
+    $updates_using_rc = civicrm_api3('Activity', 'getcount', [
+      'status_id'        => ['IN' => ['Scheduled', 'Needs Review']],
+      $rcUpdateField     => $contribution_recur_id,
+      'source_record_id' => ['<>' => $contract_id],
+    ]);
+    return $contract_using_rc === 0 && $updates_using_rc === 0;
+  }
+
 
   /**
    * Render the given recurring contribution

--- a/contract.php
+++ b/contract.php
@@ -191,7 +191,8 @@ function contract_civicrm_buildForm($formName, &$form) {
           $customGroupTableId = isset($form->_groupTree[$result['custom_group_id']]['table_id']) ? $form->_groupTree[$result['custom_group_id']]['table_id'] : '-1';
           $elementName = "custom_{$result['id']}_{$customGroupTableId}";
           $form->removeElement($elementName);
-          $formUtils->addPaymentContractSelect2($elementName, $contactId, true, $id);
+          // TODO: is this dead code?
+          $formUtils->addPaymentContractSelect2($elementName, $contactId, TRUE, $id);
           // NOTE for initial launch: all custom membership fields should be editable
           $formUtils->removeMembershipEditDisallowedCustomFields();
         }

--- a/tests/phpunit/CRM/Contract/ContractTestBase.php
+++ b/tests/phpunit/CRM/Contract/ContractTestBase.php
@@ -48,9 +48,10 @@ class CRM_Contract_ContractTestBase extends \PHPUnit_Framework_TestCase implemen
     if (empty($default_creditor_id)) {
       // create if there isn't
       $creditor = $this->callAPISuccess('SepaCreditor', 'create', [
-          'creditor_type'  => 'SEPA',
-          'currency'       => 'EUR',
-          'mandate_active' => 1
+        'creditor_type'  => 'SEPA',
+        'currency'       => 'EUR',
+        'mandate_active' => 1,
+        'iban'           => 'AT483200000012345864',
       ]);
       CRM_Sepa_Logic_Settings::setSetting($creditor['id'], 'batching_default_creditor');
     }

--- a/tests/phpunit/CRM/Contract/RecurringContributionTest.php
+++ b/tests/phpunit/CRM/Contract/RecurringContributionTest.php
@@ -60,4 +60,39 @@ class CRM_Contract_RecurringContributionTest extends CRM_Contract_ContractTestBa
     $this->assertCount(0, $rcurUnused, 'Expected zero unused recurring contribution');
   }
 
+  public function testIsAssignableToContract() {
+    $contact_id = $this->createContactWithRandomEmail()['id'];
+    // create two contracts
+    $contract1 = $this->createNewContract([
+      'is_sepa'            => TRUE,
+      'amount'             => '10.00',
+      'frequency_unit'     => 'month',
+      'frequency_interval' => '1',
+      'contact_id'         => $contact_id,
+    ]);
+    $contract2 = $this->createNewContract([
+      'is_sepa'            => TRUE,
+      'amount'             => '10.00',
+      'frequency_unit'     => 'month',
+      'frequency_interval' => '1',
+      'contact_id'         => $contact_id,
+    ]);
+
+    $rcur = new CRM_Contract_RecurringContribution();
+    $this->assertTrue(
+      $rcur->isAssignableToContract(
+        $contract1['membership_payment.membership_recurring_contribution'],
+        $contract1['id']
+      ),
+      'Recurring contribution should be assignable to its membership'
+    );
+    $this->assertFalse(
+      $rcur->isAssignableToContract(
+        $contract1['membership_payment.membership_recurring_contribution'],
+        $contract2['id']
+      ),
+      'Recurring contribution should NOT be assignable to other memberships'
+    );
+  }
+
 }

--- a/tests/phpunit/CRM/Contract/RecurringContributionTest.php
+++ b/tests/phpunit/CRM/Contract/RecurringContributionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Class CRM_Contract_RecurringContributionTest
+ *
+ * @group headless
+ */
+class CRM_Contract_RecurringContributionTest extends CRM_Contract_ContractTestBase {
+
+  public function testGetAll() {
+    $contact_id = $this->createContactWithRandomEmail()['id'];
+    // create a contract with an associated recurring contribution
+    $contract = $this->createNewContract([
+      'is_sepa'            => TRUE,
+      'amount'             => '10.00',
+      'frequency_unit'     => 'month',
+      'frequency_interval' => '1',
+      'contact_id'         => $contact_id,
+    ]);
+    // create a second contract
+    $this->createNewContract([
+      'is_sepa'            => TRUE,
+      'amount'             => '12.00',
+      'frequency_unit'     => 'month',
+      'frequency_interval' => '1',
+      'contact_id'         => $contact_id,
+    ]);
+    // create another recurring contribution that is not in use
+    $rcurManual = $this->callAPISuccess('ContributionRecur', 'create', [
+      'contact_id'             => $contact_id,
+      'amount'                 => 15,
+      'frequency_interval'     => 12,
+      'contribution_status_id' => 'Pending',
+      'payment_instrument_id'  => 'Credit Card',
+    ]);
+    $rcur = new CRM_Contract_RecurringContribution();
+    // get unused recurring contributions for this contact
+    $rcurUnused = $rcur->getAll($contact_id);
+    $this->assertCount(1, $rcurUnused, 'Expected one unused recurring contribution');
+    $rcurUnused = reset($rcurUnused);
+    $this->assertEquals('15.00', $rcurUnused['fields']['amount'], 'Expected unused recurring contribution');
+    // get all recurring contributions for this contact
+    $rcurAll = $rcur->getAll($contact_id, FALSE);
+    $this->assertCount(3, $rcurAll, 'Expected three recurring contributions');
+    // get unused recurring contributions or recurring contributions belonging to $contract
+    $rcurAll = $rcur->getAll($contact_id, TRUE, $contract['id']);
+    $this->assertCount(2, $rcurAll, 'Expected two recurring contributions');
+    // schedule (but don't execute) an update to the manually-created recurring contribution
+    $update = [
+      'membership_payment.membership_recurring_contribution' => $rcurManual['id'],
+    ];
+    $this->modifyContract(
+      $contract['id'],
+      'update',
+      'now + 1 day',
+      $update
+    );
+    // get unused recurring contributions for this contact
+    $rcurUnused = $rcur->getAll($contact_id, TRUE, NULL, FALSE);
+    $this->assertCount(0, $rcurUnused, 'Expected zero unused recurring contribution');
+  }
+
+}


### PR DESCRIPTION
This fixes two issues with reused recurring contributions:
* An issue where recurring contributions that are used in scheduled (future) contract updates are not considered as already assigned, meaning they can be used (selected in the UI) for other updates and thus potentially assigned to multiple memberships.
* Adds an engine check to ensure that recurring contributions used in contract updates are not associated with other contracts when the contract update is executed. This uses the default engine error handling, meaning failures will lead to a "Failed" contract update ("Recurring contribution already in use for different contract").

Includes some semi-related code formatting fixes.