### PR TITLE
GP-10618 Add ability to synchronize with ContributionRecur

### DIFF
--- a/CRM/Contract/Change/SynchronizeContributionRecur.php
+++ b/CRM/Contract/Change/SynchronizeContributionRecur.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Synchronize membership payment data based on recurring contribution
+ *
+ * This is a pseudo change class - it's not really an activity!
+ */
+class CRM_Contract_Change_SynchronizeContributionRecur extends CRM_Contract_Change {
+
+  public function __construct($data) {
+    $this->data = $data;
+  }
+
+  public function getRequiredFields() {
+    throw new Exception('Unreachable code');
+  }
+
+  /**
+   * Fetch recurring contribution and sync to membership payment fields
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function execute() {
+    $this->getContract(TRUE);
+    // build an array just with the recurring contribution and ID
+    $updates = [
+      'id' => $this->getContractID(),
+      'membership_payment.membership_recurring_contribution' => $this->contract['membership_payment.membership_recurring_contribution'],
+    ];
+    // let derivePayment add other payment related fields based on ContributionRecur
+    $this->derivePaymentData($updates);
+    CRM_Contract_CustomData::resolveCustomFields($updates);
+    // push fields back to the membership custom fields
+    civicrm_api3('Membership', 'create', $updates);
+  }
+
+  public function renderDefaultSubject($contract_after, $contract_before = NULL) {
+    throw new Exception('Unreachable code');
+  }
+
+}

--- a/api/v3/Contract/SynchronizeContributionRecur.php
+++ b/api/v3/Contract/SynchronizeContributionRecur.php
@@ -1,0 +1,47 @@
+<?php
+use CRM_Contract_ExtensionUtil as E;
+
+/**
+ * Contract.SynchronizeContributionRecur API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/api-architecture/
+ */
+function _civicrm_api3_contract_synchronize_contribution_recur_spec(&$spec) {
+  $spec['id'] = [
+    'name'         => 'id',
+    'title'        => 'Contract ID',
+    'api.aliases'  => ['contract_id'],
+    'api.required' => 1,
+    'description'  => 'Contract (Membership) ID of the contract to be synchronized',
+  ];
+}
+
+/**
+ * Refresh contract details based on recurring contribution data
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ *
+ * @throws API_Exception
+ */
+function civicrm_api3_contract_synchronize_contribution_recur($params) {
+  // get membership and ensure ContributionRecur is set
+  $rcurId = civicrm_api3('Membership', 'getvalue', [
+    'id'     => $params['id'],
+    'return' => CRM_Contract_Utils::getCustomFieldId('membership_payment.membership_recurring_contribution'),
+  ]);
+  $sync = new CRM_Contract_Change_SynchronizeContributionRecur([
+    'source_record_id' => $params['id'],
+  ]);
+  $sync->execute();
+  return civicrm_api3_create_success(civicrm_api3('Membership', 'getsingle', [
+    'id'     => $params['id'],
+  ]));
+}


### PR DESCRIPTION
This adds a new `Contract.synchronize_contribution_recur` API which allows the synchronization of data from recurring contributions to the contract payment information fields. This allows changes made to recurring contributions outside of CE to be fed back into CE data structures.

The implementation was done in a pseudo change class which, unlike all other change types, is not actually backed by an activity, but rather just used ad-hoc via the API.