### PR TITLE
GP-10885 Apply contract updates stored in resume activities

### DIFF
--- a/CRM/Contract/Change/Resume.php
+++ b/CRM/Contract/Change/Resume.php
@@ -11,7 +11,7 @@ use CRM_Contract_ExtensionUtil as E;
 /**
  * "Resume Membership" change
  */
-class CRM_Contract_Change_Resume extends CRM_Contract_Change {
+class CRM_Contract_Change_Resume extends CRM_Contract_Change_Upgrade {
 
   /**
    * Get a list of required fields for this type
@@ -28,44 +28,23 @@ class CRM_Contract_Change_Resume extends CRM_Contract_Change {
    * @throws Exception should anything go wrong in the execution
    */
   public function execute() {
-    $contract = $this->getContract(TRUE);
+    $contract_before = $this->getContract(TRUE);
 
-    // pause the mandate
-    $payment_contract_id = CRM_Utils_Array::value('membership_payment.membership_recurring_contribution', $contract);
-    if ($payment_contract_id) {
-      CRM_Contract_SepaLogic::resumeSepaMandate($payment_contract_id);
-      $this->updateContract(['status_id' => 'Current']);
+    // get any changes stored in the resume activity
+    $contract_update = $this->buildContractUpdate($contract_before);
+    $contract_update['status_id'] = 'Current';
+
+    if (empty($contract_update['membership_payment.membership_recurring_contribution'])) {
+      // recurring contribution is unchanged - resume it
+      CRM_Contract_SepaLogic::resumeSepaMandate(
+        CRM_Utils_Array::value('membership_payment.membership_recurring_contribution', $contract_before)
+      );
     }
 
-    // update change activity
-    $contract_after = $this->getContract(TRUE);
-    $this->setParameter('subject', $this->getSubject($contract_after, $contract));
-    $this->setStatus('Completed');
-    $this->save();
-  }
+    // perform the update
+    $this->updateContract($contract_update);
+    $this->updateChangeActivity($this->getContract(), $contract_before);
 
-  /**
-   * Render the default subject
-   *
-   * @param $contract_after       array  data of the contract after
-   * @param $contract_before      array  data of the contract before
-   * @return                      string the subject line
-   */
-  public function renderDefaultSubject($contract_after, $contract_before = NULL) {
-    $contract_id = $this->getContractID();
-    if ($this->isNew()) {
-      // FIXME: replicating weird behaviour by old engine
-      return "id{$contract_id}:";
-    } else {
-
-      $subject = "id{$contract_id}:";
-      if (!empty($this->data['contract_cancellation.contact_history_cancel_reason'])) {
-        // FIXME: replicating weird behaviour by old engine
-        $subject .= ' cancel reason ' . $this->resolveValue($this->data['contract_cancellation.contact_history_cancel_reason'], 'contract_cancellation.contact_history_cancel_reason');
-        //$subject .= ' cancel reason ' . $this->labelValue($this->data['contract_cancellation.contact_history_cancel_reason'], 'contract_cancellation.contact_history_cancel_reason');
-      }
-      return $subject;
-    }
   }
 
   /**
@@ -84,6 +63,17 @@ class CRM_Contract_Change_Resume extends CRM_Contract_Change {
    */
   public static function getChangeTitle() {
     return E::ts("Resume Contract");
+  }
+
+  /**
+   * Modify action links provided to the user for a given membership
+   *
+   * @param array $links
+   * @param string $current_status_name
+   * @param array $membership_data
+   */
+  public static function modifyMembershipActionLinks(&$links, $current_status_name, $membership_data) {
+    // no-op
   }
 
 }

--- a/tests/phpunit/CRM/Contract/ContractTestBase.php
+++ b/tests/phpunit/CRM/Contract/ContractTestBase.php
@@ -482,4 +482,20 @@ class CRM_Contract_ContractTestBase extends \PHPUnit_Framework_TestCase implemen
   public function setActivityFlavour($type) {
     // TODO: this needs to be implemented when other flavours are available
   }
+
+  /**
+   * Get mandate currently associated with a contract
+   *
+   * @param $contract_id
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function getMandateForContract($contract_id) {
+    $contract = $this->getContract($contract_id);
+    return civicrm_api3('SepaMandate', 'getsingle', [
+      'entity_table' => 'civicrm_contribution_recur',
+      'entity_id' => $contract['membership_payment.membership_recurring_contribution'],
+    ]);
+  }
 }


### PR DESCRIPTION
This changes `CRM_Contract_Change_Resume` to apply contract updates that may be added to the resume activity, similar to how `CRM_Contract_Change_Revive` is handled.

Some extraction refactoring in `CRM_Contract_Change_Upgrade` is included to facilitate this change while avoiding duplication of code.