### PR TITLE
GP-10951 Set recurring contribution cancel date

### DIFF
--- a/CRM/Contract/SepaLogic.php
+++ b/CRM/Contract/SepaLogic.php
@@ -222,6 +222,7 @@ class CRM_Contract_SepaLogic {
         civicrm_api3('ContributionRecur', 'create', array(
           'id'                     => $recurring_contribution_id,
           'end_date'               => date('YmdHis'),
+          'cancel_date'            => date('YmdHis'),
           'contribution_status_id' => 1));
       }
     }

--- a/tests/phpunit/CRM/Contract/BasicEngineTest.php
+++ b/tests/phpunit/CRM/Contract/BasicEngineTest.php
@@ -91,6 +91,15 @@ class CRM_Contract_BasicEngineTest extends CRM_Contract_ContractTestBase {
         $cancelReasonOptionValue,
         "'cancel_reason' of the recurring contribution should be ${cancelReasonOptionValue} (='Unknown')"
       );
+
+      $this->assertNotEmpty(
+        $recurringContribution->cancel_date,
+        'cancel_date should be set after cancellation'
+      );
+      $this->assertNotEmpty(
+        $recurringContribution->end_date,
+        'end_date should be set after cancellation'
+      );
     }
   }
 


### PR DESCRIPTION
This changes the cancellation process to set `cancel_date` in `civicrm_contribution_recur` in addition to `end_date`.