### PR TITLE
GP-15906 Convert scheduled legacy contract updates

### DIFF
--- a/CRM/Contract/Upgrader.php
+++ b/CRM/Contract/Upgrader.php
@@ -91,10 +91,50 @@ class CRM_Contract_Upgrader extends CRM_Contract_Upgrader_Base {
     return TRUE;
   }
 
-  public function upgrade_1403() {
-    $this->ctx->log->info('Applying update 1403');
+  /**
+   * Convert scheduled legacy update activities by adding ch_payment_changes
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function convertLegacyUpdates() {
+    $paymentChangeField = \CRM_Contract_CustomData::getCustomFieldKey(
+      'contract_updates',
+      'ch_payment_changes'
+    );
+    $scheduledActivities = civicrm_api3('Activity', 'get', [
+      'activity_type_id'  => ['IN' => ['Contract_Updated', 'Contract_Revived']],
+      'status_id'         => ['IN' => ['Scheduled', 'Failed', 'Needs Review']],
+      $paymentChangeField => ['IS NULL' => 1],
+      'options'           => ['limit' => 0],
+    ])['values'];
+
+    foreach ($scheduledActivities as $activity) {
+      try {
+        $paymentChanges = CRM_Contract_Utils::getPaymentChangesForLegacyUpdate($activity);
+        civicrm_api3('Activity', 'create', [
+          'id'                => $activity['id'],
+          $paymentChangeField => json_encode($paymentChanges),
+        ]);
+      }
+      catch (API_Exception $e) {
+        $this->ctx->log->err("Unable to convert legacy update activity with ID :{$activity['id']}: " . $e->getMessage());
+      }
+      catch (Exception $e) {
+        civicrm_api3('Activity', 'create', [
+          'id'        => $activity['id'],
+          'status_id' => 'Failed',
+          'details'   => 'Unable to generate Payment Change for legacy update: ' . $e->getMessage(),
+        ]);
+        $this->ctx->log->warning($e->getMessage());
+      }
+    }
+  }
+
+  public function upgrade_1500() {
+    $this->ctx->log->info('Applying update 1500');
     $customData = new CRM_Contract_CustomData('de.systopia.contract');
     $customData->syncCustomGroup(__DIR__ . '/../../resources/custom_group_contract_updates.json');
+    $this->convertLegacyUpdates();
     return TRUE;
   }
 }

--- a/CRM/Contract/Utils.php
+++ b/CRM/Contract/Utils.php
@@ -466,4 +466,39 @@ class CRM_Contract_Utils
       "frequency_unit"     => $frequency_unit,
     ];
   }
+
+  /**
+   * Calculate payment changes for a given legacy SEPA contract update activity
+   *
+   * @param array $activity
+   *
+   * @return array
+   * @throws \Exception
+   */
+  public static function getPaymentChangesForLegacyUpdate(array $activity) {
+    CRM_Contract_CustomData::labelCustomFields($activity);
+    $requiredFields = [
+      'contract_updates.ch_cycle_day',
+      'contract_updates.ch_from_ba',
+      'contract_updates.ch_annual',
+      'contract_updates.ch_frequency',
+    ];
+    foreach ($requiredFields as $requiredField) {
+      if (empty($activity[$requiredField])) {
+        throw new Exception("{$requiredField} must not be empty");
+      }
+    }
+    return [
+      'activity_type_id' => $activity['activity_type_id'],
+      'adapter' => CRM_Contract_PaymentAdapter_SEPAMandate::ADAPTER_ID,
+      'parameters' => [
+        'campaign_id' => $activity['campaign_id'] ?? "",
+        'cycle_day' => $activity['contract_updates.ch_cycle_day'],
+        'from_ba' => $activity['contract_updates.ch_from_ba'],
+        'annual' => $activity['contract_updates.ch_annual'],
+        'frequency' => $activity['contract_updates.ch_frequency'],
+        'defer_payment_start' => $activity['contract_updates.defer_payment_start'] ?? 0,
+      ],
+    ];
+  }
 }

--- a/tests/phpunit/CRM/Contract/UtilsTest.php
+++ b/tests/phpunit/CRM/Contract/UtilsTest.php
@@ -31,4 +31,29 @@ class CRM_Contract_UtilsTest extends CRM_Contract_ContractTestBase {
     );
   }
 
+  public function testGetPaymentChangesForLegacyUpdate() {
+    $activity = [
+      'activity_type_id' => 123,
+      'campaign_id' => 345,
+      'contract_updates.ch_cycle_day' => 5,
+      'contract_updates.ch_from_ba' => 1,
+      'contract_updates.ch_annual' => 100.50,
+      'contract_updates.ch_frequency' => 12,
+      'contract_updates.defer_payment_start' => 0,
+    ];
+    $result = CRM_Contract_Utils::getPaymentChangesForLegacyUpdate($activity);
+    $this->assertArraysEqual([
+      'activity_type_id' => '123',
+      'adapter' => CRM_Contract_PaymentAdapter_SEPAMandate::ADAPTER_ID,
+      'parameters' => [
+        'campaign_id'         => 345,
+        'cycle_day'           => 5,
+        'from_ba'             => 1,
+        'annual'              => 100.50,
+        'frequency'           => 12,
+        'defer_payment_start' => 0
+      ],
+    ], $result);
+  }
+
 }


### PR DESCRIPTION
This adds an upgrader that converts existing scheduled contract updates that were created prior to the introduction of `ch_payment_changes`.

The upgrader works under the assumption that all existing updates use the SEPA payment adapter.