### PR TITLE
GP-26059 Fix conflict check not being limited by activity type

### DIFF
--- a/CRM/Contract/Change.php
+++ b/CRM/Contract/Change.php
@@ -31,7 +31,7 @@ abstract class CRM_Contract_Change implements CRM_Contract_Change_SubjectRendere
    * List of known changes,
    *  activity_type_name => change class
    */
-  protected static $type2class = [
+  public static $type2class = [
     'Contract_Signed'    => 'CRM_Contract_Change_Sign',
     'Contract_Cancelled' => 'CRM_Contract_Change_Cancel',
     'Contract_Updated'   => 'CRM_Contract_Change_Upgrade',

--- a/CRM/Contract/Handler/ModificationConflicts.php
+++ b/CRM/Contract/Handler/ModificationConflicts.php
@@ -51,6 +51,7 @@ class CRM_Contract_Handler_ModificationConflicts{
     $scheduledModifications = civicrm_api3('activity', 'get', [
       'option.limit' => 10000, // If we have more than 10,000 scheduled updates for this contract, probably time to review organisational proceedures
       'source_record_id' => $this->contractId,
+      'activity_type_id' => ['IN' => array_keys(CRM_Contract_Change::$type2class)],
       'status_id' => ['IN' => ['scheduled', 'needs review']]
     ])['values'];
     foreach($scheduledModifications as $k => &$scheduledModification){


### PR DESCRIPTION
This fixes an issue where the conflict check will look at any activity with a matching `source_record_id` regardless of activity type, rather than just looking at contract change activities.