### PR TITLE
GP-42503 Fix missing permissions for Contract.start_date API

### DIFF
--- a/contract.php
+++ b/contract.php
@@ -383,6 +383,12 @@ function contract_civicrm_permission(&$permissions) {
   ];
 }
 
+function contract_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  if (strtolower($entity) == 'contract' && strtolower($action) == 'start_date') {
+    $permissions[$entity][$action] = ['access CiviMember'];
+  }
+}
+
 /**
  * Entity Types Hook
  * @param $entityTypes


### PR DESCRIPTION
This fixes an issue where no explicit permission was required for the `Contract.start_date` API, meaning Civi would require "administer CiviCRM" as a fallback in execution contexts with `check_permission=1` (like REST calls via `CRM.api3`).