### PR TITLE
GP-43756 Fix ContributionRecur status not being set to In Progress after resume/revive

### DIFF
--- a/CRM/Contract/PaymentAdapter/Adyen.php
+++ b/CRM/Contract/PaymentAdapter/Adyen.php
@@ -54,7 +54,7 @@ class CRM_Contract_PaymentAdapter_Adyen implements CRM_Contract_PaymentAdapter {
     $paymentProcessorID = $paymentToken['payment_processor_id'];
     $defaultShopperReference = CRM_Utils_Array::value('cr.processor_id', $paymentToken);
 
-    $pendingOptVal = (int) CRM_Contract_Utils::getOptionValue('contribution_recur_status', 'Pending');
+    $inProgressOptVal = (int) CRM_Contract_Utils::getOptionValue('contribution_recur_status', 'In Progress');
     $defaultCurrency = Civi::settings()->get('defaultCurrency');
     $memberDuesTypeID = CRM_Contract_Utils::getFinancialTypeID('Member Dues');
 
@@ -70,7 +70,7 @@ class CRM_Contract_PaymentAdapter_Adyen implements CRM_Contract_PaymentAdapter {
       'amount'                       => [ 'amount'                 , TRUE              , NULL                        ],
       'campaign_id'                  => [ 'campaign_id'            , FALSE             , NULL                        ],
       'contact_id'                   => [ 'contact_id'             , TRUE              , NULL                        ],
-      'contribution_status_id'       => [ 'contribution_status_id' , FALSE             , $pendingOptVal              ],
+      'contribution_status_id'       => [ 'contribution_status_id' , FALSE             , $inProgressOptVal           ],
       'currency'                     => [ 'currency'               , FALSE             , $defaultCurrency            ],
       'cycle_day'                    => [ 'cycle_day'              , FALSE             , $startDate->format('d')     ],
       'financial_type_id'            => [ 'financial_type_id'      , FALSE             , $memberDuesTypeID           ],
@@ -412,21 +412,21 @@ class CRM_Contract_PaymentAdapter_Adyen implements CRM_Contract_PaymentAdapter {
     if (count($update) < 1) {
       Api4\ContributionRecur::update(FALSE)
         ->addWhere('id', '=', $recurringContributionID)
-        ->addValue('contribution_status_id:name', 'Pending')
+        ->addValue('contribution_status_id:name', 'In Progress')
         ->execute();
 
       return $recurringContributionID;
     }
 
-    $pendingOptVal = (int) CRM_Contract_Utils::getOptionValue(
+    $inProgressOptVal = (int) CRM_Contract_Utils::getOptionValue(
       'contribution_recur_status',
-      'Pending'
+      'In Progress'
     );
 
     $update['contribution_status_id'] = CRM_Utils_Array::value(
       'contribution_status_id',
       $update,
-      $pendingOptVal
+      $inProgressOptVal
     );
 
     return self::update($recurringContributionID, $update);
@@ -436,15 +436,15 @@ class CRM_Contract_PaymentAdapter_Adyen implements CRM_Contract_PaymentAdapter {
     $update['cancel_date'] = NULL;
     $update['cancel_reason'] = NULL;
 
-    $pendingOptVal = (int) CRM_Contract_Utils::getOptionValue(
+    $inProgressOptVal = (int) CRM_Contract_Utils::getOptionValue(
       'contribution_recur_status',
-      'Pending'
+      'In Progress'
     );
 
     $update['contribution_status_id'] = CRM_Utils_Array::value(
       'contribution_status_id',
       $update,
-      $pendingOptVal
+      $inProgressOptVal
     );
 
     return self::update($recurringContributionID, $update);

--- a/tests/phpunit/CRM/Contract/PaymentAdapter/AdyenTest.php
+++ b/tests/phpunit/CRM/Contract/PaymentAdapter/AdyenTest.php
@@ -298,8 +298,7 @@ class CRM_Contract_PaymentAdapter_AdyenTest extends CRM_Contract_PaymentAdapterT
   public function testPauseAndResume() {
 
     // --- Create a payment --- //
-
-    CRM_Contract_PaymentAdapter_Adyen::create([
+    $recurId = CRM_Contract_PaymentAdapter_Adyen::create([
       'amount'                   => 10.0,
       'contact_id'               => $this->contact['id'],
       'payment_processor_id'     => $this->paymentProcessor['id'],
@@ -308,10 +307,11 @@ class CRM_Contract_PaymentAdapter_AdyenTest extends CRM_Contract_PaymentAdapterT
 
     $recurContribQuery = Api4\ContributionRecur::get(FALSE)
       ->addSelect('contribution_status_id:name')
+      ->addWhere('id', $recurId)
       ->execute();
 
     $recurringContribution = $recurContribQuery->first();
-    $this->assertEquals('Pending', $recurringContribution['contribution_status_id:name']);
+    $this->assertEquals('In Progress', $recurringContribution['contribution_status_id:name']);
 
     // --- Pause the payment --- //
 
@@ -339,7 +339,7 @@ class CRM_Contract_PaymentAdapter_AdyenTest extends CRM_Contract_PaymentAdapterT
       ->execute()
       ->first();
 
-    $this->assertEquals('Pending', $recurringContribution['contribution_status_id:name']);
+    $this->assertEquals('In Progress', $recurringContribution['contribution_status_id:name']);
 
   }
 
@@ -448,7 +448,7 @@ class CRM_Contract_PaymentAdapter_AdyenTest extends CRM_Contract_PaymentAdapterT
       'amount'                       => 15.0,
       'cancel_date'                  => NULL,
       'cancel_reason'                => NULL,
-      'contribution_status_id:name'  => 'Pending',
+      'contribution_status_id:name'  => 'In Progress',
       'cycle_day'                    => 28,
       'id'                           => $newRecurContribID,
       'next_sched_contribution_date' => $reviveDate->format('Y-m-d H:i:s'),
@@ -476,7 +476,7 @@ class CRM_Contract_PaymentAdapter_AdyenTest extends CRM_Contract_PaymentAdapterT
     $this->assertEquals(1, $recurContribQuery->rowCount);
 
     $recurringContribution = $recurContribQuery->first();
-    $this->assertEquals('Pending', $recurringContribution['contribution_status_id:name']);
+    $this->assertEquals('In Progress', $recurringContribution['contribution_status_id:name']);
 
     // --- Terminate the payment --- //
 
@@ -524,7 +524,6 @@ class CRM_Contract_PaymentAdapter_AdyenTest extends CRM_Contract_PaymentAdapterT
     $creditCardOptVal = (int) $this->getOptionValue('payment_instrument', 'Credit Card');
     $debitCardOptVal = (int) $this->getOptionValue('payment_instrument', 'Debit Card');
     $inProgressOptVal = (int) $this->getOptionValue('contribution_recur_status', 'In Progress');
-    $pendingOptVal = (int) $this->getOptionValue('contribution_recur_status', 'Pending');
 
     $recurContribID = CRM_Contract_PaymentAdapter_Adyen::create([
       'amount'                => 10.0,
@@ -565,7 +564,7 @@ class CRM_Contract_PaymentAdapter_AdyenTest extends CRM_Contract_PaymentAdapterT
     $this->assertEquals([
       'amount'                       => 10.0,
       'campaign_id'                  => $this->campaign['id'],
-      'contribution_status_id:name'  => 'Pending',
+      'contribution_status_id:name'  => 'In Progress',
       'currency'                     => 'EUR',
       'cycle_day'                    => 13,
       'financial_type_id'            => $memberDuesTypeID,

--- a/tests/phpunit/api/v3/Contract/SignContractTest.php
+++ b/tests/phpunit/api/v3/Contract/SignContractTest.php
@@ -75,7 +75,7 @@ class api_v3_Contract_SignContractTest extends api_v3_Contract_ContractTestBase 
     $this->assertEachEquals([
       [10.0                                , $rc['amount']                     ],
       [$this->contact['id']                , $rc['contact_id']                 ],
-      ['Pending'                           , $rc['contribution_status_id:name']],
+      ['In Progress'                       , $rc['contribution_status_id:name']],
       [$cycle_day                          , $rc['cycle_day']                  ],
       [$financial_type                     , $rc['financial_type_id']          ],
       [1                                   , $rc['frequency_interval']         ],


### PR DESCRIPTION
This fixes an issue where `ContributionRecurs` are updated to status "Pending" instead of "In Progress" when processing revives and resumes.

The Adyen payment processor only performs debits on `ContributionRecurs` with status "In Progress".