### PR TITLE
GP-2213 Fix annual amount diff calculation for amounts >=1k

### DIFF
--- a/CRM/Contract/Change/Resume.php
+++ b/CRM/Contract/Change/Resume.php
@@ -201,7 +201,7 @@ class CRM_Contract_Change_Resume extends CRM_Contract_Change {
 
     $annual_before = $contract_before["membership_payment.membership_annual"];
     $annual_after = $contract_after["membership_payment.membership_annual"];
-    $this->setParameter("contract_updates.ch_annual_diff", $annual_after - $annual_before);
+    $this->setParameter("contract_updates.ch_annual_diff", CRM_Contract_Utils::formatMoney($annual_after) - CRM_Contract_Utils::formatMoney($annual_before));
 
     $this->setParameter("subject", $this->getSubject($contract_after, $contract_before));
     $this->setParameter("activity_date_time", date("Y-m-d H:i:s"));

--- a/CRM/Contract/Change/Revive.php
+++ b/CRM/Contract/Change/Revive.php
@@ -342,7 +342,7 @@ class CRM_Contract_Change_Revive extends CRM_Contract_Change {
         $this->setParameter($change_field, $contract_after[$membership_field]);
       }
     }
-    $this->setParameter('contract_updates.ch_annual_diff', $contract_after['membership_payment.membership_annual'] - $contract_before['membership_payment.membership_annual']);
+    $this->setParameter('contract_updates.ch_annual_diff', CRM_Contract_Utils::formatMoney($contract_after['membership_payment.membership_annual']) - CRM_Contract_Utils::formatMoney($contract_before['membership_payment.membership_annual']));
     $this->setParameter('subject', $this->getSubject($contract_after, $contract_before));
     $this->setParameter("activity_date_time", date('Y-m-d H:i:s'));
     $this->setStatus('Completed');

--- a/CRM/Contract/Change/Sign.php
+++ b/CRM/Contract/Change/Sign.php
@@ -37,7 +37,7 @@ class CRM_Contract_Change_Sign extends CRM_Contract_Change {
   public function populateData() {
     parent::populateData();
     $contract = $this->getContract(TRUE);
-    $this->data['contract_updates.ch_annual_diff'] = CRM_Utils_Array::value('membership_payment.membership_annual', $contract, '');
+    $this->data['contract_updates.ch_annual_diff'] = CRM_Contract_Utils::formatMoney(CRM_Utils_Array::value('membership_payment.membership_annual', $contract, ''));
   }
 
 

--- a/CRM/Contract/Change/Upgrade.php
+++ b/CRM/Contract/Change/Upgrade.php
@@ -168,7 +168,8 @@ class CRM_Contract_Change_Upgrade extends CRM_Contract_Change {
         $this->setParameter($change_field, $contract_after[$membership_field]);
       }
     }
-    $this->setParameter('contract_updates.ch_annual_diff', $contract_after['membership_payment.membership_annual'] - $contract_before['membership_payment.membership_annual']);
+    // $this->setParameter('contract_updates.ch_annual_diff', $contract_after['membership_payment.membership_annual'] - $contract_before['membership_payment.membership_annual']);
+    $this->setParameter('contract_updates.ch_annual_diff', CRM_Contract_Utils::formatMoney($contract_after['membership_payment.membership_annual']) - CRM_Contract_Utils::formatMoney($contract_before['membership_payment.membership_annual']));
     $this->setParameter('subject', $this->getSubject($contract_after, $contract_before));
     $this->setParameter("activity_date_time", date('Y-m-d H:i:s'));
     $this->setStatus('Completed');

--- a/tests/phpunit/CRM/Contract/PaymentAdapter/AdyenTest.php
+++ b/tests/phpunit/CRM/Contract/PaymentAdapter/AdyenTest.php
@@ -311,7 +311,7 @@ class CRM_Contract_PaymentAdapter_AdyenTest extends CRM_Contract_PaymentAdapterT
 
     $recurContribQuery = Api4\ContributionRecur::get(FALSE)
       ->addSelect('contribution_status_id:name')
-      ->addWhere('id', $recurId)
+      ->addWhere('id', '=', $recurId)
       ->execute();
 
     $recurringContribution = $recurContribQuery->first();


### PR DESCRIPTION
This fixes an issue where money formating was breaking the annual amount calculation, effectively truncating numbers after the thousands separator.