### PR TITLE
GP-44971 Fix cancel failing when ContractPaymentLink is missing

### DIFF
--- a/CRM/Contract/Change/Cancel.php
+++ b/CRM/Contract/Change/Cancel.php
@@ -85,13 +85,17 @@ class CRM_Contract_Change_Cancel extends CRM_Contract_Change {
           "contribution_status_id" => 1,
         ]);
       }
-
       // end the contract payment link
-      $contract_payment_link = civicrm_api3('ContractPaymentLink', 'getsingle', [
-        'contract_id'           => $contract['id'],
-        'contribution_recur_id' => $recurring_contribution_id,
-        'return'                => ['id'],
-      ]);
+      $contract_payment_link = [];
+      try {
+        $contract_payment_link = civicrm_api3('ContractPaymentLink', 'getsingle', [
+          'contract_id'           => $contract['id'],
+          'contribution_recur_id' => $recurring_contribution_id,
+          'return'                => ['id'],
+        ]);
+      } catch (CiviCRM_API3_Exception $e) {
+        Civi::log()->warning("Unable to determine ContractPaymentLink when cancelling contract {$contract['id']} with ContributionRecur {$recurring_contribution_id}: {$e->getMessage()}");
+      }
 
       if (isset($contract_payment_link['id'])) {
         CRM_Contract_BAO_ContractPaymentLink::endPaymentLink($contract_payment_link['id']);


### PR DESCRIPTION
This fixes an issue where cancellations fail if there is no `ContractPaymentLink` for a contract and recurring contribution. This scenario only occurs for memberships that were not properly migrated.