### PR TITLE
GP-47975 Clear next_sched_contributon_date for SEPA and use API4

### DIFF
--- a/CRM/Contract/PaymentAdapter/EFT.php
+++ b/CRM/Contract/PaymentAdapter/EFT.php
@@ -1,6 +1,7 @@
 <?php
 
 use Civi\Api4;
+use Civi\Api4\ContributionRecur;
 
 class CRM_Contract_PaymentAdapter_EFT implements CRM_Contract_PaymentAdapter {
 
@@ -361,19 +362,15 @@ class CRM_Contract_PaymentAdapter_EFT implements CRM_Contract_PaymentAdapter {
     public static function terminate ($recurring_contribution_id, $reason = "CHNG") {
         $now = date("Y-m-d H:i:s");
 
-        $update_result = civicrm_api3("ContributionRecur", "create", [
-            "id"                           => $recurring_contribution_id,
-            "cancel_date"                  => $now,
-            "cancel_reason"                => $reason,
-            "contribution_status_id"       => "Completed",
-            "end_date"                     => $now,
-            "next_sched_contribution_date" => NULL,
-        ]);
+        ContributionRecur::update(FALSE)
+          ->addValue('cancel_date', $now)
+          ->addValue('end_date', $now)
+          ->addValue('cancel_reason', $reason)
+          ->addValue('contribution_status_id:name', 'Completed')
+          ->addValue('next_sched_contribution_date', NULL)
 
-        if ($update_result["is_error"]) {
-            $error_message = $update_result["error_message"];
-            throw new Exception("Contribution cannot be terminated: $error_message");
-        }
+          ->addWhere('id', '=', $recurring_contribution_id)
+          ->execute();
     }
 
     /**

--- a/CRM/Contract/PaymentAdapter/SEPAMandate.php
+++ b/CRM/Contract/PaymentAdapter/SEPAMandate.php
@@ -1,6 +1,7 @@
 <?php
 
 use Civi\Api4;
+use Civi\Api4\ContributionRecur;
 
 class CRM_Contract_PaymentAdapter_SEPAMandate implements CRM_Contract_PaymentAdapter {
 
@@ -414,7 +415,7 @@ class CRM_Contract_PaymentAdapter_SEPAMandate implements CRM_Contract_PaymentAda
             throw new Exception("SEPA mandate cannot be paused: $error_message");
         }
 
-        Api4\ContributionRecur::update(FALSE)
+        ContributionRecur::update(FALSE)
             ->addWhere('id', '=', $recurring_contribution_id)
             ->addValue('contribution_status_id:name', 'Paused')
             ->execute();
@@ -457,7 +458,7 @@ class CRM_Contract_PaymentAdapter_SEPAMandate implements CRM_Contract_PaymentAda
             throw new Exception("SEPA mandate cannot be resumed: $error_message");
         }
 
-        Api4\ContributionRecur::update(FALSE)
+        ContributionRecur::update(FALSE)
             ->addWhere('id', '=', $recurring_contribution_id)
             ->addValue('contribution_status_id:name', 'Pending')
             ->execute();
@@ -492,7 +493,7 @@ class CRM_Contract_PaymentAdapter_SEPAMandate implements CRM_Contract_PaymentAda
         // Notice days
 
         $start_date->add(self::noticeDays());
-        
+
         // Minimum date
 
         if (isset($params['min_date'])) {
@@ -605,10 +606,11 @@ class CRM_Contract_PaymentAdapter_SEPAMandate implements CRM_Contract_PaymentAda
 
         // Set the cancel_reason explicitly again since
         // CRM_Sepa_BAO_SEPAMandate::terminateMandate seems to ignore this parameter,
-        civicrm_api3("ContributionRecur", "create", [
-            "id"            => $recurring_contribution_id,
-            "cancel_reason" => $reason,
-        ]);
+        ContributionRecur::update(FALSE)
+          ->addValue('next_sched_contribution_date', NULL)
+          ->addValue('cancel_reason', $reason)
+          ->addWhere('id', '=', $recurring_contribution_id)
+          ->execute();
     }
 
     /**

--- a/tests/phpunit/CRM/Contract/PaymentAdapter/AdyenTest.php
+++ b/tests/phpunit/CRM/Contract/PaymentAdapter/AdyenTest.php
@@ -393,23 +393,25 @@ class CRM_Contract_PaymentAdapter_AdyenTest extends CRM_Contract_PaymentAdapterT
         'frequency_interval',
         'frequency_unit:name',
         'payment_token_id',
-        'start_date'
+        'start_date',
+        'next_sched_contribution_date',
       )
       ->addWhere('id', '=', $recurContribID)
       ->execute()
       ->first();
 
     $this->assertEquals([
-      'amount'                      => 20.0,
-      'cancel_date'                 => $cancelledRC['cancel_date'],
-      'cancel_reason'               => 'CHNG',
-      'contribution_status_id:name' => 'Completed',
-      'cycle_day'                   => 15,
-      'frequency_interval'          => 2,
-      'frequency_unit:name'         => 'month',
-      'id'                          => $recurContribID,
-      'payment_token_id'            => $cancelledRC['payment_token_id'],
-      'start_date'                  => $startDate->format('Y-m-d H:i:s'),
+      'amount'                       => 20.0,
+      'cancel_date'                  => $cancelledRC['cancel_date'],
+      'cancel_reason'                => 'CHNG',
+      'contribution_status_id:name'  => 'Completed',
+      'cycle_day'                    => 15,
+      'frequency_interval'           => 2,
+      'frequency_unit:name'          => 'month',
+      'id'                           => $recurContribID,
+      'payment_token_id'             => $cancelledRC['payment_token_id'],
+      'start_date'                   => $startDate->format('Y-m-d H:i:s'),
+      'next_sched_contribution_date' => NULL,
     ], $cancelledRC);
 
     $this->assertNotNull($cancelledRC['cancel_date']);
@@ -494,7 +496,7 @@ class CRM_Contract_PaymentAdapter_AdyenTest extends CRM_Contract_PaymentAdapterT
         'cancel_reason',
         'contribution_status_id:name',
         'end_date',
-        // 'next_sched_contribution_date'
+        'next_sched_contribution_date',
       )
       ->addWhere('id', '=', $recurringContribution['id'])
       ->execute()
@@ -506,7 +508,7 @@ class CRM_Contract_PaymentAdapter_AdyenTest extends CRM_Contract_PaymentAdapterT
       'contribution_status_id:name'  => 'Completed',
       'end_date'                     => $recurringContribution['end_date'],
       'id'                           => $recurringContribution['id'],
-      // 'next_sched_contribution_date' => NULL,
+      'next_sched_contribution_date' => NULL,
     ], $recurringContribution);
 
     // Recurring contribution should have ended within the last minute


### PR DESCRIPTION
This changes the terminate SEPA payment adapter method to explicitly clear `next_sched_contributon_date` and switches all updates to API4 to work around the silly NULL handling in API3.